### PR TITLE
Added planets function

### DIFF
--- a/endlessparser/datatypes/Map.py
+++ b/endlessparser/datatypes/Map.py
@@ -61,6 +61,14 @@ class SystemNode(HasName, HasPosition, HasObjects, HasMusic, HasGovernment):
     def links(self) -> List[str]:
         return [child.tokens_as_string() for child in self._find_children("link")]
 
+    def planets(self) -> List[str]:
+        l = []
+        for object in self.objects():
+            if object.tokens: l.append(object.tokens_as_string())
+            for o in object.objects(): #To include stations
+                if o.tokens: l.append(o.tokens_as_string())
+        return l
+    
     def minables(self) -> Dict[str, Tuple[float, float]]:
         d = {}
         for child in self._find_children("minables"):


### PR DESCRIPTION
This adds a function that returns the names of all landable objects in a system: wormholes, planets and stations.
But there's an "issue" (I don't know if it's considered one) where if the system has a ringworld it will return 10 things with the same name since a ringworld is composed of multiple smaller objects.